### PR TITLE
fix naming in futures

### DIFF
--- a/04-delayed-computing/01-futures/main.go
+++ b/04-delayed-computing/01-futures/main.go
@@ -33,9 +33,9 @@ func main() {
 
 	fmt.Println("Requests started")
 
-	body1 := <-future1
-	body2 := <-future2
+	response1 := <-future1
+	response2 := <-future2
 
-	fmt.Printf("Response 1: %v\n", body1)
-	fmt.Printf("Response 2: %v\n", body2)
+	fmt.Printf("Response 1: %v\n", response1)
+	fmt.Printf("Response 2: %v\n", response2)
 }

--- a/04-delayed-computing/01.1-futures-with-retries/main.go
+++ b/04-delayed-computing/01.1-futures-with-retries/main.go
@@ -47,9 +47,9 @@ func main() {
 
 	fmt.Println("Requests started")
 
-	body1 := <-future1
-	body2 := <-future2
+	response1 := <-future1
+	response2 := <-future2
 
-	fmt.Printf("Response 1: %v\n", body1)
-	fmt.Printf("Response 2: %v\n", body2)
+	fmt.Printf("Response 1: %v\n", response1)
+	fmt.Printf("Response 2: %v\n", response2)
 }


### PR DESCRIPTION
There are variables `body1` and `body2` in the futures-related files. Actually, they are not bodies, but complex structures with bodies as part of them, and we can even see this in the output. That naming is a little confusing when reading the code. So my proposal is to rename these variables to `response1` and `response2` respectively.